### PR TITLE
Всё, что связано с режимом измерений, доступно только для ATmega128 ПРАВКА: представлена другая реализация для 328

### DIFF
--- a/rscs/include/rscs/adc.h
+++ b/rscs/include/rscs/adc.h
@@ -65,12 +65,13 @@ typedef enum {
 	RSCS_ADC_REF_INTERNAL_2DOT56= 3,
 } rscs_adc_ref_t;
 
+#ifdef __AVR_ATmega128__
 //! Режим работы АЦП - непрерывный или одиночный
 typedef enum {
 	RSCS_ADC_MODE_SINGLE 	= 0, 		//!< Одиночный
 	RSCS_ADC_MODE_CONTINIOUS= 1,	//!< Непрерывный
 } rscs_adc_mode_t;
-
+#endif
 
 //! Инициализация АЦП
 /*! Параметры по-умолчанию:
@@ -91,9 +92,11 @@ void rscs_adc_set_refrence(rscs_adc_ref_t ref);
 	от изменения значений до их применения может пройти некоторое время(см. даташит)*/
 void rscs_adc_set_prescaler(rscs_adc_prescaler_t presc);
 
-//! Установка режима
+#ifdef __AVR_ATmega128__
+//! Установка режима (только ATmega128)
 //  от изменения значений до их применения может пройти некоторое время(см. даташит)
 void rscs_adc_set_mode(rscs_adc_mode_t mode);
+#endif
 
 //! Начало измерения. Вернет RSCS_E_BUSY если, уже есть измерение в процессе.
 rscs_e rscs_adc_start_conversion(rscs_adc_channel_t channel);

--- a/rscs/include/rscs/adc.h
+++ b/rscs/include/rscs/adc.h
@@ -65,13 +65,11 @@ typedef enum {
 	RSCS_ADC_REF_INTERNAL_2DOT56= 3,
 } rscs_adc_ref_t;
 
-#ifdef __AVR_ATmega128__
 //! Режим работы АЦП - непрерывный или одиночный
 typedef enum {
 	RSCS_ADC_MODE_SINGLE 	= 0, 		//!< Одиночный
 	RSCS_ADC_MODE_CONTINIOUS= 1,	//!< Непрерывный
 } rscs_adc_mode_t;
-#endif
 
 //! Инициализация АЦП
 /*! Параметры по-умолчанию:

--- a/rscs/src/adc.c
+++ b/rscs/src/adc.c
@@ -58,13 +58,17 @@ void rscs_adc_set_prescaler(rscs_adc_prescaler_t presc){
 	ADCSRA |= presc;
 }
 
-#ifdef __AVR_ATmega128__
 void rscs_adc_set_mode(rscs_adc_mode_t mode){
+#ifdef __AVR_ATmega128__
 	ADCSRA &= ~(1 << ADFR);
 
 	ADCSRA |= (mode << ADFR);
-}
+#elif defined __AVR_ATmega328P__
+	ADCSRA &= ~(1 << ADATE);
+
+	ADCSRA |= (mode << ADATE);
 #endif
+}
 
 rscs_e rscs_adc_get_result(int32_t * value_ptr, rscs_adc_channel_t channel) {
 

--- a/rscs/src/adc.c
+++ b/rscs/src/adc.c
@@ -58,11 +58,13 @@ void rscs_adc_set_prescaler(rscs_adc_prescaler_t presc){
 	ADCSRA |= presc;
 }
 
+#ifdef __AVR_ATmega128__
 void rscs_adc_set_mode(rscs_adc_mode_t mode){
 	ADCSRA &= ~(1 << ADFR);
 
 	ADCSRA |= (mode << ADFR);
 }
+#endif
 
 rscs_e rscs_adc_get_result(int32_t * value_ptr, rscs_adc_channel_t channel) {
 


### PR DESCRIPTION
В ATmega328 нет режимов измерения, поэтому всё, что с ними связано, должно быть только для 128.(знаю,что надо было в developer, перепутал)
ПРАВКА: представлена другая реализация для 328